### PR TITLE
35 update graphs to not hide most used processes

### DIFF
--- a/arbiter3/arbiter/conf.py
+++ b/arbiter3/arbiter/conf.py
@@ -77,9 +77,14 @@ except AttributeError:
     raise ImproperlyConfigured("setting PROMETHEUS_VERIFY_SSL is required")
 
 try:
-    PROMETHEUS_AUTH = settings.PROMETHEUS_AUTH
+    PROMETHEUS_USERNAME = settings.PROMETHEUS_USERNAME
 except AttributeError:
-    raise ImproperlyConfigured("setting PROMETHEUS_AUTH is required")
+    raise ImproperlyConfigured("setting PROMETHEUS_USERNAME is required")
+
+try:
+    PROMETHEUS_PASSWORD = settings.PROMETHEUS_PASSWORD
+except AttributeError:
+    raise ImproperlyConfigured("setting PROMETHEUS_PASSWORD is required")
 
 ########## WARDEN SETTINGS ##########
 
@@ -108,14 +113,7 @@ try:
 except AttributeError:
     raise ImproperlyConfigured("setting WARDEN_BEARER is required")
 
-from prometheus_api_client import PrometheusConnect
 
-PROMETHEUS_CONNECTION = PrometheusConnect(
-    url=PROMETHEUS_URL, auth=PROMETHEUS_AUTH, disable_ssl=(not PROMETHEUS_VERIFY_SSL)
-)
+from arbiter3.arbiter.promclient import PrometheusSession
 
-# FIXME this will hang if route is not reachable, timeout does not seem to work
-#if not PROMETHEUS_CONNECTION.check_prometheus_connection():
-#    raise ImproperlyConfigured(
-#        "Prometheus cannot be reached. Is PROMETHEUS_URL, PROMETHEUS_USER, PROMETHEUS_PASS, and PROMETHEUS_DISABLE_SSL properly configured?"
-#    )
+PROMETHEUS_CONNECTION = PrometheusSession(base_url=PROMETHEUS_URL, username=PROMETHEUS_USERNAME, password=PROMETHEUS_PASSWORD, verify=PROMETHEUS_VERIFY_SSL)

--- a/arbiter3/arbiter/eval.py
+++ b/arbiter3/arbiter/eval.py
@@ -96,20 +96,20 @@ def query_violations(policies: list[Policy]) -> list[Violation]:
     for policy in policies:
 
         try:
-            response = PROMETHEUS_CONNECTION.custom_query(policy.query)
+            response = PROMETHEUS_CONNECTION.query(policy.query)
         except PrometheusApiClientException as e:
             logger.error(f"Unable to query violations: {e}")
             return violations
 
         for result in response:
-            cgroup = result["metric"]["cgroup"]
+            cgroup = result.metric['cgroup']
             matches = re.findall(r"^/user.slice/(user-\d+.slice)$", cgroup)
             if len(matches) < 1:
                 logger.warning(f"invalid cgroup: {cgroup}")
                 continue
             unit = matches[0]
-            host, port = split_port(result["metric"]["instance"])
-            username = result["metric"]["username"]
+            host, port = split_port(result.metric["instance"])
+            username = result.metric["username"]
 
             if get_uid(unit) < ARBITER_MIN_UID:
                 continue
@@ -129,8 +129,8 @@ def query_violations(policies: list[Policy]) -> list[Violation]:
 @log_debug
 def get_affected_hosts(domain) -> list[str]:
     up_query = f"up{{job=~'{WARDEN_JOB}', instance=~'{domain}'}}"
-    result = PROMETHEUS_CONNECTION.custom_query(up_query)
-    return [split_port(r["metric"]["instance"]) for r in result]
+    result = PROMETHEUS_CONNECTION.query(up_query)
+    return [split_port(r.metric["instance"]) for r in result]
 
 
 @log_debug

--- a/arbiter3/arbiter/plots.py
+++ b/arbiter3/arbiter/plots.py
@@ -31,7 +31,7 @@ def usage_graph(query: str, start: datetime, end: datetime, step: str, color_by:
     matrices = sort_matrices_by_avg(matrices)
 
     if color_by == 'proc':
-        matrices = combine_last_matrices(matrices, 10)
+        matrices = combine_last_matrices(matrices, 9)
 
     fig = Figure()
     for a in reversed(matrices):

--- a/arbiter3/arbiter/plots.py
+++ b/arbiter3/arbiter/plots.py
@@ -1,15 +1,15 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
-from plotly.graph_objects import Figure
-from prometheus_api_client import MetricRangeDataFrame, PrometheusApiClientException
-import plotly.express as px
+from plotly.graph_objects import Figure, Scatter
 
 from django.utils.timezone import get_current_timezone, localtime
 
 from arbiter3.arbiter.models import Violation
 from arbiter3.arbiter.utils import bytes_to_gib, BYTES_PER_GIB
 from arbiter3.arbiter.conf import PROMETHEUS_CONNECTION
+from arbiter3.arbiter.promclient import sort_matrices_by_avg, combine_last_matrices
+
 
 logger = logging.getLogger(__name__)
 
@@ -21,11 +21,38 @@ class QueryError(Exception):
 def usage_graph(query: str, start: datetime, end: datetime, step: str, color_by: str, threshold: float | int | None) -> Figure:
 
     try:
-        result = PROMETHEUS_CONNECTION.custom_query_range(
-            query, start_time=start, end_time=end, step=step)
-    except PrometheusApiClientException as e:
-        raise QueryError(f"Could not run query: {e}")
+        matrices = PROMETHEUS_CONNECTION.query_range(query=query, start=start.timestamp(), end=end.timestamp(), step=step)
+    except Exception as e:
+        raise QueryError(f'Could not run query: {e}')
 
+    if not matrices:
+        raise QueryError(f"Query returned no results: {query}")
+
+    matrices = sort_matrices_by_avg(matrices)
+
+    if color_by == 'proc':
+        matrices = combine_last_matrices(matrices, 10)
+
+    fig = Figure()
+    for a in reversed(matrices):
+        timestamps = [datetime.fromtimestamp(s.timestamp) for s in a.values]
+        values = [float(s.value) for s in a.values]
+
+        fig.add_trace(
+            Scatter(
+                x=timestamps, 
+                y=values,
+                hoverinfo="name+x+y",
+                mode='lines',
+                line=dict(width=0.0),
+                stackgroup='one',
+                name=a.metric[color_by] 
+            ),
+        )
+
+    return fig
+
+    """
     if not result:
         raise QueryError(
             f"Query returned no results: {query}. Try increasing step size.")
@@ -46,6 +73,7 @@ def usage_graph(query: str, start: datetime, end: datetime, step: str, color_by:
         graph.add_hline(threshold, line={"dash": "dot", "color": "grey"})
 
     return graph
+    """
 
 
 def cpu_usage_figure(host: str, start: datetime, end: datetime, step="30s", username: str = None, threshold: float = None) -> Figure | None:

--- a/arbiter3/arbiter/promclient.py
+++ b/arbiter3/arbiter/promclient.py
@@ -1,0 +1,133 @@
+import requests
+from urllib.parse import urljoin
+from collections import defaultdict
+from typing import NamedTuple
+
+class Series(NamedTuple):
+    timestamp: int
+    value: str
+
+
+class Vector(NamedTuple):
+    metric: dict[str, str]
+    value: Series
+
+
+class Matrix(NamedTuple):
+    metric: dict[str, str]
+    values: list[Series]
+
+def parse_vector_result(result: dict[str, str]) -> list[Vector]:
+    vectors = []
+    for r in result:
+        metric = r['metric']
+        value = Series(*r['value'])
+        vector = Vector(metric, value)
+        vectors.append(vector)
+    return vectors
+
+
+def parse_matrix_result(result: dict[str, str]) -> list[Matrix]:
+    matrices = []
+    for r in result:
+        labels = r["metric"]
+        series = []
+        for stamp, value in r["values"]:
+            series.append(Series(stamp, value))
+        matrices.append(Matrix(labels, series))
+    return matrices
+
+
+class PrometheusSession(requests.Session):
+    def __init__(self, base_url, username=None, password=None, verify=True, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.base_url = base_url if base_url.endswith("/") else base_url + "/"
+        self.headers.update({"Content-Type": "application/json"})
+        if username and password:
+            self.auth = requests.auth.HTTPBasicAuth(username, password)
+
+
+    def get(self, path, *args, **kwargs):
+        return super().get(urljoin(self.base_url, path), *args, **kwargs)
+
+
+    def validate_response(self, response: requests.Response):
+        response.raise_for_status()
+        return response.json()
+
+
+    def query(self, query, time=None, timeout=None) -> list[Vector] | list[Matrix]:
+        """
+        https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+        """
+        
+        params = {"query": query}
+
+        if time:
+            params["time"] = time
+
+        if timeout:
+            params["timeout"] = timeout
+
+        response = self.get("api/v1/query", params=params)
+        data = self.validate_response(response)['data']
+        match data['resultType']:
+            case 'matrix':
+                return parse_matrix_result(data['result'])
+            case 'vector':
+                return parse_vector_result(data['result'])
+            case _:
+                raise NotImplementedError
+
+
+    def query_range(self, query, start, end, step, timeout=None) -> list[Matrix]:
+        """
+        https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
+        """
+
+        params = {
+            "query": query,
+            "start": start,
+            "end": end,
+            "step": step,
+        }
+
+        if timeout:
+            params['timeout'] = timeout
+
+        response = self.get("api/v1/query_range", params=params)
+        data = self.validate_response(response)['data']
+        match data['resultType']:
+            case 'matrix':
+                return parse_matrix_result(data['result'])
+            case _:
+                raise NotImplementedError 
+            
+
+def sort_matrices_by_avg(matrices: list[Matrix]) -> list[Matrix]:
+    averages = []
+    for m in matrices:
+        total = sum([float(s.value) for s in m.values])
+        count = len(m.values)
+        average = total / count
+        averages.append( (average, m) )
+    averages = sorted(averages, key=lambda a: a[0], reverse=True)
+    return [r[1] for r in averages]
+
+
+def combine_last_matrices(matrices: list[Matrix], n: int) -> list[Matrix]:
+    if len(matrices) < n:
+        return matrices
+    keep = matrices[:n]
+    combine = matrices[n:]
+    other_sums = defaultdict(int)
+    for m in combine:
+        for ts, v in m.values:
+            other_sums[ts] += float(v)
+    if sum(other_sums.values()) == 0:
+        return keep
+    other_values = [Series(ts, v) for ts, v in other_sums.items()]
+    other_matrix = Matrix(metric=dict(proc='other'), values=other_values)
+
+    keep.append(other_matrix)
+    return keep

--- a/arbiter3/arbiter/views/dashboard.py
+++ b/arbiter3/arbiter/views/dashboard.py
@@ -27,9 +27,8 @@ def message_http(message: str, status: str = "success"):
 def view_dashboard(request):
     agents = []
     try:
-        result = PROMETHEUS_CONNECTION.custom_query(
-            f'up{{job="{WARDEN_JOB}"}} > 0')
-        agents = [metric["metric"]["instance"] for metric in result]
+        result = PROMETHEUS_CONNECTION.query(f'up{{job="{WARDEN_JOB}"}} == 1')
+        agents = [r.metric['instance'] for r in result]
     except Exception as e:
         LOGGER.error(
             f"Could not query prometheus for cgroup-agent instances: {e}")

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -20,7 +20,9 @@ PROMETHEUS_URL = 'http://prometheus:9090'
 PROMETHEUS_VERIFY_SSL = False
 
 # if using basic auth set to tuple (username, password)
-PROMETHEUS_AUTH = None
+PROMETHEUS_USERNAME = None
+
+PROMETHEUS_PASSWORD = None
 
 
 # ============================================================

--- a/testing/vagrant/Vagrantfile
+++ b/testing/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.configure("2") do |config|
   # config.vm.box = "generic/rocky9"
-  # config.vm.box = "generic/rocky8"
-  config.vm.box = "generic/ubuntu2004"
+  config.vm.box = "generic/rocky8"
+  #config.vm.box = "generic/ubuntu2004"
   config.vm.network "private_network", ip: "192.168.56.2"
   config.vm.network "forwarded_port", guest: 2112, host: 2112, host_ip: "127.0.0.1"
   config.vm.synced_folder ".", "/vagrant/cgroup-warden"


### PR DESCRIPTION
Modify graph creation so only 9 named processes are included, and the others are grouped. 

- Migrate away from using pandas for graph creation to simplify process aggregation
  - Remove PrometheusClient dependency
  - Add arbiter3.arbiter.promclient for querying prometheus
- Take average of process usage, keep top nine, combine all others into 'other' process

closes #35 