### PR TITLE
Add limit refresh

### DIFF
--- a/arbiter3/arbiter/conf.py
+++ b/arbiter3/arbiter/conf.py
@@ -230,3 +230,11 @@ except AttributeError:
     raise ImproperlyConfigured("setting WARDEN_BEARER is required")
 except AssertionError:
     raise ImproperlyConfigured("setting WARDEN_BEARER is a string or None")
+
+try:
+    WARDEN_RUNTIME = settings.WARDEN_RUNTIME
+    assert isinstance(WARDEN_RUNTIME, bool) 
+except AttributeError:
+    raise ImproperlyConfigured("setting WARDEN_RUNTIME is required")
+except AssertionError:
+    raise ImproperlyConfigured("setting WARDEN_RUNTIME is a bool")

--- a/arbiter3/arbiter/management/commands/evaluate.py
+++ b/arbiter3/arbiter/management/commands/evaluate.py
@@ -1,7 +1,8 @@
 from django.core.management.base import BaseCommand
-from arbiter3.arbiter.eval import evaluate
+from arbiter3.arbiter.eval import evaluate, refresh_limits
 from django.utils import timezone
 from arbiter3.arbiter.models import Policy
+from arbiter3.arbiter.utils import promtime_to_sec
 from time import sleep
 
 
@@ -13,21 +14,28 @@ class Command(BaseCommand):
         parser.add_argument("-S", "--seconds", default=0, type=int)
         parser.add_argument("-M", "--minutes", default=0, type=int)
         parser.add_argument("-H", "--hours", default=0, type=int)
+        parser.add_argument("--refresh-interval", default="10m", type=str)
 
     def handle(self, *args, **options):
         seconds = options["seconds"]
         minutes = options["minutes"]
         hours = options["hours"]
 
-        cycle_time = timezone.timedelta(
-            seconds=seconds, minutes=minutes, hours=hours
-        ).total_seconds()
+        cycle_time = timezone.timedelta(seconds=seconds, minutes=minutes, hours=hours).total_seconds()
+        refresh_time = promtime_to_sec(options["refresh_interval"])
+
+        seconds_since_last_refresh = refresh_time
 
         while True:
             if options["policies"]:
                 policies = Policy.objects.filter(name__in=options["policies"])
             else:
                 policies = Policy.objects.all()
+
+            seconds_since_last_refresh += cycle_time
+            if seconds_since_last_refresh >= refresh_time:
+                seconds_since_last_refresh = 0
+                refresh_limits()
 
             evaluate(policies)
             sleep(cycle_time)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,7 +106,9 @@ The arbiter evaluation loop can be run with
 ```
 ./arbiter.py evaluate
 ```
-To run it in a loop, you can pass the `--seconds`, `--minutes`, or `--hours` flags.
+To run it in a loop, you can pass the `--seconds`, `--minutes`, or `--hours` flags. 
+
+Additionally, you may pass the `--refresh-interval` flag, of the format `1h15m5s`, to determine the interval at which arbiter ensures reported limits are accurate. Default is `10m`. 
 
 This should also be set up to run as a service, see `arbiter-eval.service`.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -30,6 +30,8 @@ resource limits.
 
 `WARDEN_BEARER` **(string | None)** : If given, will be used as the bearer token to authenticate with the cgroup-wardens.
 
+`WARDEN_RUNTIME` **(bool)** : If enabled, the cgroup-warden will not write out persistant drop-in files for limits in `/etc/systemd`, and will instead write these files to `/run`. This means that when enabled, upon reboot all limits will be reset. Arbiter will account for this and sync limits, requiring no action. 
+
 ## Email
 `ARBITER_NOTIFY_USERS` **(bool)** : If enabled, arbiter will email users about their violations.
 

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -39,6 +39,8 @@ WARDEN_USE_TLS = True
 
 WARDEN_BEARER = 'insecure-95axve4fn4j2u8ih0j1ltg272g1n297l8'
 
+WARDEN_RUNTIME = True
+
 
 # ============================================================
 #                           Email


### PR DESCRIPTION
Add the ability to set limits with `cgroup-warden` with `runtime=True/`, which does not make the limits persistent through reboots.  This is set with the `WARDEN_RUNTIME` setting. 

To ensure proper limits are applied, at a given interval, (passed to eval as `--refresh-interval`) read reported limits from the warden and update the state within arbiter.