### PR TITLE
Various minor fixes and tweaks

### DIFF
--- a/arbiter3/arbiter/eval.py
+++ b/arbiter3/arbiter/eval.py
@@ -206,8 +206,8 @@ def evaluate(policies=None):
     violations = query_violations(policies)
     Violation.objects.bulk_create(violations, ignore_conflicts=True)
 
-    unexpired = Violation.objects.filter(
-        Q(expiration__gt=timezone.now()) | Q(expiration__isnull=True))
+
+    unexpired = Violation.objects.filter(Q(expiration__gt=timezone.now()) | Q(expiration__isnull=True), policy__active=True)
     unexpired = unexpired.prefetch_related("policy")
 
     targets = Target.objects.all()

--- a/arbiter3/arbiter/management/commands/evaluate.py
+++ b/arbiter3/arbiter/management/commands/evaluate.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
                     policies = Policy.objects.all()
 
                 evaluate(policies)
-                #sleep(cycle_time)
+                sleep(cycle_time)
                 if cycle_time == 0:
                     break
             except OperationalError:

--- a/arbiter3/arbiter/management/commands/evaluate.py
+++ b/arbiter3/arbiter/management/commands/evaluate.py
@@ -1,9 +1,9 @@
 from django.core.management.base import BaseCommand
-from arbiter3.arbiter.eval import evaluate
+from arbiter3.arbiter.eval import evaluate, logger
 from django.utils import timezone
+from django.db.utils import OperationalError
 from arbiter3.arbiter.models import Policy
 from time import sleep
-
 
 class Command(BaseCommand):
     help = "Runs the entire arbiter service (Gets violations and applies penalties)"
@@ -24,12 +24,17 @@ class Command(BaseCommand):
         ).total_seconds()
 
         while True:
-            if options["policies"]:
-                policies = Policy.objects.filter(name__in=options["policies"])
-            else:
-                policies = Policy.objects.all()
+            try:
+                if options["policies"]:
+                    policies = Policy.objects.filter(name__in=options["policies"])
+                else:
+                    policies = Policy.objects.all()
 
-            evaluate(policies)
-            sleep(cycle_time)
-            if cycle_time == 0:
-                break
+                evaluate(policies)
+                #sleep(cycle_time)
+                if cycle_time == 0:
+                    break
+            except OperationalError:
+                logger.warning('evaluate loop failed to complete on operation error, likely an issue with concurency with sqlite locking the database')
+
+

--- a/arbiter3/arbiter/models.py
+++ b/arbiter3/arbiter/models.py
@@ -55,19 +55,24 @@ class QueryData:
         We do not want to whitelist memory usage, as that cannot be 'taken' back.  
         """
 
-        filters = f'instance=~"{domain}"'
+        like_filters = {'instance':domain}
+        notlike_filters = dict()
 
         lookback = int(lookback.total_seconds())
 
         if params.user_whitelist:
-            filters += f', user!~"{params.user_whitelist}"'
+            notlike_filters['user'] = params.user_whitelist
 
         if params.proc_whitelist:
-            cpu_query = sum_by(increase(Q('cgroup_warden_proc_cpu_usage_seconds').like(instance=domain).not_like(
-                proc=params.proc_whitelist).over(f'{lookback}s')) / lookback > params.cpu_threshold, "username", "instance", "cgroup")
+            notlike_filters['proc'] = params.proc_whitelist
+            cpu_query = sum_by(
+                increase(
+                    Q('cgroup_warden_proc_cpu_usage_seconds').like(**like_filters).not_like(**notlike_filters).over(f'{lookback}s')
+                ) / lookback > params.cpu_threshold, 
+                "username", "instance", "cgroup"
+            )
         else:
-            cpu_query = increase(Q('cgroup_warden_cpu_usage_seconds').like(
-                instance=domain).over(f'{lookback}s')) / lookback > params.cpu_threshold
+            cpu_query = increase(Q('cgroup_warden_cpu_usage_seconds').like(**like_filters).over(f'{lookback}s')) / lookback > params.cpu_threshold
 
         granularity = 30
 
@@ -79,8 +84,9 @@ class QueryData:
             datapoints = lookback
             mem_range = f'{lookback}s:1s'
 
-        mem_query = sum_over_time(Q('cgroup_warden_memory_usage_bytes').like(
-            instance=domain).over(mem_range)) / datapoints > params.mem_threshold
+        mem_query = sum_over_time(
+            Q('cgroup_warden_memory_usage_bytes').like(**like_filters).over(mem_range)
+            ) / datapoints > params.mem_threshold
 
         if params.mem_threshold and params.cpu_threshold:
             query = cpu_query.lor(mem_query)

--- a/arbiter3/arbiter/models.py
+++ b/arbiter3/arbiter/models.py
@@ -32,7 +32,6 @@ class QueryData:
     params: QueryParameters | None
 
     def json(self):
-        print(f"e:{self.params}")
         json_params = self.params.json() if self.params else None
         return {"query": self.query, "params": json_params}
 

--- a/arbiter3/arbiter/templates/arbiter/user_breakdown.html
+++ b/arbiter3/arbiter/templates/arbiter/user_breakdown.html
@@ -48,7 +48,7 @@ User Breakdown for {{ username }}
 
             </div>
             <div class="user-recent-viol-box">
-                <h3>Most Recent Violation History (expired)</h3>
+                <h3>Most Recent Violation History</h3>
                 <hr class="box-divider">
                 <ul class="notification-table">
                     {% for violation in recent_violations %}

--- a/arbiter3/arbiter/templates/arbiter/violation_list.html
+++ b/arbiter3/arbiter/templates/arbiter/violation_list.html
@@ -1,4 +1,10 @@
 {% extends "arbiter/base.html" %}
+{% load static %}
+
+{% block extrastyle %}
+{{block.super}}
+    <link rel="stylesheet" href="{% static 'css/list-view.css' %}">
+{% endblock %}
 
 {% block page-title %}
     Violations
@@ -11,19 +17,42 @@
             Violation
         </th>
         <th>
-            Expiration
+            Offense Number
+        </th>
+        <th>
+            Timestamp
         </th>
     </thead>
     <tbody>
         {% for violation in object_list %}
             <tr>
                 <td><a href="{% url 'arbiter:change-violation' violation.id%}">{{violation}}</a></td>
-                <td>{{violation.expiration}}</td>
+                <td>{{violation.offense_count}}</td>
+                <td>{{violation.timestamp}}</td>
             </tr>
         {% endfor %}
     </tbody>
 </table>
-
+<br>
+{% if is_paginated %}
+    {% if page_obj.has_previous %}
+        <a href='?page=1'>&laquo;</a>
+        <a href='?page={{ page_obj.previous_page_number }}'>&lsaquo;</a>
+    {% endif %}
+    {% for page_num in page_obj.paginator.page_range %}
+        {% if page_num <= page_obj.number|add:3  and page_num >= page_obj.number|add:-3 %}
+            {% if page_num == page_obj.number %}
+                <a class="current-page" href='?page={{ page_num }}'>{{ page_num }}</a>
+            {% else %}
+                <a href='?page={{ page_num }}'>{{ page_num }}</a>
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+    {% if page_obj.has_next %}
+        <a href='?page={{ page_obj.next_page_number }}'>&rsaquo;</a>
+        <a href='?page={{ page_obj.paginator.num_pages }}'>&raquo;</a>
+    {% endif %}
+{% endif %} 
 
 {% endblock content %}
 

--- a/arbiter3/arbiter/views/base_policy.py
+++ b/arbiter3/arbiter/views/base_policy.py
@@ -86,7 +86,7 @@ class BasePolicyForm(forms.ModelForm):
             filters += f', user!~"{whitelist}"'
             params = QueryParameters(0, 0, user_whitelist=self.cleaned_data["user_whitelist"])
         
-        policy.query_data = QueryData.raw_query(f'systemd_unit_cpu_usage_ns{{{filters}}}', params).json()
+        policy.query_data = QueryData.raw_query(f'cgroup_warden_cpu_usage_seconds{{{filters}}}', params).json()
         policy.save()
 
 

--- a/arbiter3/arbiter/views/dashboard.py
+++ b/arbiter3/arbiter/views/dashboard.py
@@ -40,7 +40,7 @@ def view_dashboard(request):
 
     context = dict(
         title="Dashboard",
-        violations=Violation.objects.all().order_by("-timestamp")[:10],
+        violations=Violation.objects.filter(is_base_status=False).order_by("-timestamp")[:10],
         agents=agents,
         limits=prop_list,
         last_evaluated=last_eval.timestamp if last_eval else "Never",

--- a/arbiter3/arbiter/views/usage_policy.py
+++ b/arbiter3/arbiter/views/usage_policy.py
@@ -72,7 +72,7 @@ class UsagePolicyForm(forms.ModelForm):
     proc_whitelist = forms.CharField(
         label="Query Process Whitelist", required=False)
     user_whitelist = forms.CharField(
-        label="Query User Whitelist", required=False)
+        label="Query User Whitelist", required=False, initial="arbiter|nobody")
     cpu_threshold = forms.FloatField(
         label="Query CPU Threshold", required=False)
     mem_threshold = forms.FloatField(

--- a/arbiter3/arbiter/views/user.py
+++ b/arbiter3/arbiter/views/user.py
@@ -40,8 +40,8 @@ def get_user_breakdown(request, username):
         return redirect("arbiter:user-lookup")
 
     
-    active_violations = Violation.objects.filter(target__username=username).exclude(expiration__lt = timezone.now())
-    recent_violations = Violation.objects.filter(target__username=username, expiration__isnull=False).order_by("-timestamp")[:10]
+    active_violations = Violation.objects.filter(target__username=username, policy__active=True).exclude(expiration__lt = timezone.now())
+    recent_violations = Violation.objects.filter(target__username=username, is_base_status=False, policy__active=True).order_by("-timestamp")[:10]
 
     context = {"navbar": navbar(request),"title": "User Breakdown", "username":username, "targets": targets, "active_violations": active_violations, "recent_violations": recent_violations}
 

--- a/arbiter3/arbiter/views/violation.py
+++ b/arbiter3/arbiter/views/violation.py
@@ -8,7 +8,6 @@ from django.urls import reverse_lazy
 
 from arbiter3.arbiter.conf import ARBITER_USER_LOOKUP
 from arbiter3.arbiter.models import Violation
-from django.utils.module_loading import import_string
 from .nav import navbar
 
 try:
@@ -22,6 +21,8 @@ except ImportError:
 class ViolationListView(LoginRequiredMixin, ListView):
     model = Violation
     login_url = reverse_lazy("login")
+    paginate_by = 50
+    ordering = ["-timestamp"]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/arbiter3/arbiter/views/violation.py
+++ b/arbiter3/arbiter/views/violation.py
@@ -29,6 +29,9 @@ class ViolationListView(LoginRequiredMixin, ListView):
         context["navbar"] = navbar(self.request)
         context["title"] = "Violations"
         return context
+    
+    def get_queryset(self):
+        return super().get_queryset().filter(is_base_status=False, policy__active=True)
 
 
 @login_required(login_url=reverse_lazy("login"))

--- a/arbiter3/portal/static/css/dashboard.css
+++ b/arbiter3/portal/static/css/dashboard.css
@@ -66,7 +66,7 @@
 
 .user-box {
     display: grid;
-    grid-template-rows: 2fr 1fr;
+    grid-template-rows: 1fr 1fr;
     grid-template-columns: 1fr 1fr;
 }
 

--- a/arbiter3/portal/static/css/list-view.css
+++ b/arbiter3/portal/static/css/list-view.css
@@ -1,0 +1,9 @@
+.current-page {
+    text-decoration: underline;
+    color: #3a0303;
+}
+
+.current-page:visited {
+    text-decoration: underline;
+}
+

--- a/arbiter3/scripts/initialize.py
+++ b/arbiter3/scripts/initialize.py
@@ -10,6 +10,13 @@ from arbiter3.scripts import config_templates
 import arbiter3.arbiter as arbiter_app
 
 
+def create_if_not_present(template, dst):
+    if not os.path.exists(dst):
+        shutil.copy(template, dst)
+        print(f"Generated {dst}")
+    else: 
+        print(f"{dst} already exists")
+
 def get_username() -> str:
     try:
         uid = os.getuid()
@@ -67,31 +74,33 @@ def initialize_config():
 
 
     # Generate config files from source templates
-    shutil.copy(manage_template, created_manage)
-    os.chmod(created_manage, 0o744)
-    print(f"Generated {created_manage}")
+    create_if_not_present(manage_template, created_manage)
+    os.chmod(created_manage, 0o740)
 
-    shutil.copy(settings_template, created_settings)
-    print(f"Generated {created_settings}")
+    create_if_not_present(settings_template, created_settings)
 
     user = get_username()
     gunicorn_path = get_gunicorn_path()
 
-    with open(created_eval_service, "w") as file:
-        file.write(eval_service_template.render(
-            working_dir=arbiter_conf_dir, user=user, python=interpreter_path))
-        print(f"Generated {created_eval_service}")
+    try:
+        with open(created_eval_service, "x") as file:
+            file.write(eval_service_template.render(
+                working_dir=arbiter_conf_dir, user=user, python=interpreter_path))
+            print(f"Generated {created_eval_service}")
+    except FileExistsError:
+        print(f"{created_eval_service} already exists")
 
-    with open(created_web_service, "w") as file:
-        file.write(web_service_template.render(
-            working_dir=arbiter_conf_dir, user=user, gunicorn_path=gunicorn_path))
-        print(f"Generated {created_web_service}")
+    try:
+        with open(created_web_service, "x") as file:
+            file.write(web_service_template.render(
+                working_dir=arbiter_conf_dir, user=user, gunicorn_path=gunicorn_path))
+            print(f"Generated {created_web_service}")
+    except FileExistsError:
+        print(f"{created_eval_service} already exists")
     
-    shutil.copy(email_body_template, created_email_body)
-    print(f"Generated {created_email_body}")
+    create_if_not_present(email_body_template, created_email_body)
 
-    shutil.copy(email_subject_template, created_email_subject)
-    print(f"Generated {created_email_subject}")
+    create_if_not_present(email_subject_template, created_email_subject)
 
 
 if __name__ == "__main__":

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -216,6 +216,24 @@ def short_low_soft_policy(db, soft_penalty):
         grace_period=timedelta(seconds=0),
     )
 
+@pytest.fixture
+def short_low_cpu_policy(db, soft_penalty):
+    params = QueryParameters(
+        cpu_threshold=CPU_LOW_THRESHOLD, mem_threshold=None
+    )
+    query = QueryData.build_query(SHORT_WINDOW, DOMAIN, params)
+    return Policy.objects.create(
+        name="short window, low only cpu threshold, soft penalty_constraints",
+        domain=".*",
+        description="description",
+        penalty_constraints=soft_penalty,
+        query_data=query.json(),
+        lookback=SHORT_WINDOW,
+        repeated_offense_scalar=0.0,
+        penalty_duration=timedelta(seconds=10),
+        repeated_offense_lookback=timedelta(seconds=0),
+        grace_period=timedelta(seconds=0),
+    )
 
 @pytest.fixture
 def short_mid_soft_policy(db, soft_penalty):
@@ -399,21 +417,24 @@ def base_medium_policy(db, medium_penalty):
 #----------------------------------
 @pytest.fixture
 def base_userwhitelist_policy(db, soft_penalty):
-    params = None
+    params = QueryParameters(0, 0,  user_whitelist='user-1001')
     query = QueryData.raw_query('cgroup_warden_cpu_usage_seconds{}', params)
 
-    return BasePolicy.objects.create(
+    pol = BasePolicy(
         name="base policy soft penalty_constraints user whitelist",
         domain=".*",
         description="description",
         penalty_constraints=soft_penalty,
         query_data=query.json(),
     )
+    pol.save()
+
+    return pol
 
 @pytest.fixture
 def low_harsh_userwhitelist_policy(db, harsh_penalty):
     params = QueryParameters(
-        cpu_threshold=CPU_LOW_THRESHOLD, mem_threshold=MEM_LOW_THRESHOLD
+        cpu_threshold=CPU_LOW_THRESHOLD, mem_threshold=MEM_LOW_THRESHOLD, user_whitelist='user-1001'
     )
     query = QueryData.build_query(SHORT_WINDOW, DOMAIN, params)
 
@@ -433,7 +454,7 @@ def low_harsh_userwhitelist_policy(db, harsh_penalty):
 @pytest.fixture
 def low_harsh_procwhitelist_policy(db, harsh_penalty):
     params = QueryParameters(
-        cpu_threshold=CPU_LOW_THRESHOLD, mem_threshold=MEM_LOW_THRESHOLD
+        cpu_threshold=CPU_LOW_THRESHOLD, mem_threshold=MEM_LOW_THRESHOLD, proc_whitelist='stress-ng-cpu'
     )
     query = QueryData.build_query(SHORT_WINDOW, DOMAIN, params)
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -135,6 +135,16 @@ def medium_penalty(db, medium_limit_cpu, medium_limit_mem):
 def soft_penalty(db, soft_limit_cpu, soft_limit_mem):
     return {'tiers': [soft_limit_cpu | soft_limit_mem]}
 
+@pytest.fixture
+def tiered_penalty(db, soft_limit_cpu, soft_limit_mem, medium_limit_cpu, medium_limit_mem, harsh_limit_cpu, harsh_limit_mem):
+    return {
+        'tiers': [
+            soft_limit_cpu | soft_limit_mem, 
+            medium_limit_cpu | medium_limit_mem, 
+            harsh_limit_cpu | harsh_limit_mem, 
+            ]
+        }
+
 
 @pytest.fixture
 def unset_penalty(db, unset_limit_cpu, unset_limit_mem):
@@ -276,7 +286,7 @@ def short_low_unset_policy(db, unset_penalty):
     )
 
 @pytest.fixture
-def short_low_tiered_policy(db, harsh_penalty):
+def short_low_tiered_policy(db, tiered_penalty):
     params = QueryParameters(
         cpu_threshold=CPU_LOW_THRESHOLD, mem_threshold=MEM_LOW_THRESHOLD
     )
@@ -285,10 +295,10 @@ def short_low_tiered_policy(db, harsh_penalty):
         name="short window, low threshold, tiered penalty",
         domain=".*",
         description="description",
-        penalty_constraints=harsh_penalty,
+        penalty_constraints=tiered_penalty,
         query_data=query.json(),
         lookback=SHORT_WINDOW,
-        repeated_offense_lookback=timedelta(seconds=0),
+        repeated_offense_lookback=timedelta(seconds=60),
         repeated_offense_scalar=0.0,
         penalty_duration=timedelta(seconds=5),
         grace_period=timedelta(seconds=0),

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -370,10 +370,10 @@ def long_lookback_with_grace_policy(db, unset_penalty):
 @pytest.fixture
 def base_soft_policy(db, soft_penalty):
     params = None
-    query = QueryData.raw_query('cgroup_warden_cpu_usage_seconds{}', params).json()
+    query = QueryData.raw_query('cgroup_warden_cpu_usage_seconds{}', params)
 
     return BasePolicy.objects.create(
-        name="short window, low threshold, soft penalty_constraints",
+        name="base policy soft penalty_constraints",
         domain=".*",
         description="description",
         penalty_constraints=soft_penalty,
@@ -383,10 +383,10 @@ def base_soft_policy(db, soft_penalty):
 @pytest.fixture
 def base_medium_policy(db, medium_penalty):
     params = None
-    query = QueryData.raw_query('cgroup_warden_cpu_usage_seconds{}', params).json()
+    query = QueryData.raw_query('cgroup_warden_cpu_usage_seconds{}', params)
 
     return BasePolicy.objects.create(
-        name="short window, low threshold, soft penalty_constraints",
+        name="base policy medium penalty_constraints",
         domain=".*",
         description="description",
         penalty_constraints=medium_penalty,
@@ -400,10 +400,10 @@ def base_medium_policy(db, medium_penalty):
 @pytest.fixture
 def base_userwhitelist_policy(db, soft_penalty):
     params = None
-    query = QueryData.raw_query('cgroup_warden_cpu_usage_seconds{}', params).json()
+    query = QueryData.raw_query('cgroup_warden_cpu_usage_seconds{}', params)
 
     return BasePolicy.objects.create(
-        name="base policy soft penalty_constraints",
+        name="base policy soft penalty_constraints user whitelist",
         domain=".*",
         description="description",
         penalty_constraints=soft_penalty,
@@ -416,6 +416,7 @@ def low_harsh_userwhitelist_policy(db, harsh_penalty):
         cpu_threshold=CPU_LOW_THRESHOLD, mem_threshold=MEM_LOW_THRESHOLD
     )
     query = QueryData.build_query(SHORT_WINDOW, DOMAIN, params)
+
     return Policy.objects.create(
         name="short window, low threshold, harsh penalty, user whitelist",
         domain=".*",

--- a/testing/test_arbiter.py
+++ b/testing/test_arbiter.py
@@ -1023,7 +1023,7 @@ def test_deactivate_reactivate_base_policy(base_soft_policy, target1):
 #         tier/limits accordingly)                     #
 ########################################################
 @pytest.mark.django_db(transaction=True)
-def test_repeeat_violation_scales_penalty_tier(short_low_tiered_policy, target1):
+def test_repeat_violation_scales_penalty_tier(short_low_tiered_policy, target1):
     # start bad behavior
     runtime = create_violation(target1, short_low_tiered_policy)
     time.sleep(runtime)

--- a/testing/util.py
+++ b/testing/util.py
@@ -108,6 +108,7 @@ def create_violating_command(policy: Policy) -> str:
     if not time:
         time = 10
     command += f" --timeout {time}s"
+
     return command
 
 


### PR DESCRIPTION
Full change list:
- evaluate no longer crashes due to a table being locked
- violation views now paginate and no longer show base/inactive policies
- deactivating a policy now makes any previous violations considered to be expired and will have limits unset next evaluation loop
- the initialization script no longer overrides files
- base policy now has a user whitelist
 
@jay-mckay the last one here was a bit odd to add given how we separated QueryParameters lmk if you think giving it a parameters will make something think its not a raw query policy and try to get a field out of it that's not present