### PR TITLE
Fix: Penalty input container sizing

### DIFF
--- a/arbiter3/arbiter/templates/arbiter/change_view.html
+++ b/arbiter3/arbiter/templates/arbiter/change_view.html
@@ -4,7 +4,7 @@
 
 {% block extrastyle %}
 {{block.super }}
-<link rel="stylesheet" href="{% static 'css/change-form.css' %}?v=1.2">
+<link rel="stylesheet" href="{% static 'css/change-form.css' %}?v=1.3">
 <link rel="stylesheet" href="{% static 'css/dashboard.css' %}?v=1.3">
 {{form.media}}
 {% endblock %}

--- a/arbiter3/portal/static/css/change-form.css
+++ b/arbiter3/portal/static/css/change-form.css
@@ -5,12 +5,19 @@ form{
 
 form > div, .form-row {
     display: grid;
-    grid-template-rows: 30% 70%;
+    grid-template-rows: 1.2em 1fr;
     grid-template-columns: 1fr 4fr;
-    /* flex-direction: row; */
     border-bottom: 1px solid var(--shadow-color);
     padding: 10px;
     margin-bottom: 20px;
+}
+
+form > div > input, form > div > select, form > div > textarea, form > div > .penalty-box{
+    grid-row: 1 / 3;
+}
+
+form > div > #penalty-messages{
+    grid-column: 2;
 }
 
 form div div{
@@ -30,7 +37,6 @@ form div input, .field-value {
 
 form div label, .form-row label{
     display: block;
-    /* width: 20%; */
     grid-row: 1;
     grid-column: 1;
 }
@@ -48,10 +54,10 @@ form div label, .form-row label{
 }
 
 .helptext{
-    padding-top: 10%;
+    /* padding-top: 10%; */
     color: var(--lighter-text-color);
     font-size: medium;
-    grid-row: 1 / 3;
+    grid-row: 2;
     grid-column: 1;
 }
 

--- a/arbiter3/portal/static/js/tiers-widget.js
+++ b/arbiter3/portal/static/js/tiers-widget.js
@@ -1,5 +1,4 @@
 window.addEventListener("load", function () {
-    console.log("loaded");
     const tiers_container = document.getElementById("tiers-content");
     const add_tier_button = document.getElementById("add-tier-button");
     const constraints_input = document.getElementById("penalty-constraints-input");

--- a/arbiter3/portal/static/js/tiers-widget.js
+++ b/arbiter3/portal/static/js/tiers-widget.js
@@ -1,4 +1,5 @@
 window.addEventListener("load", function () {
+    console.log("loaded");
     const tiers_container = document.getElementById("tiers-content");
     const add_tier_button = document.getElementById("add-tier-button");
     const constraints_input = document.getElementById("penalty-constraints-input");


### PR DESCRIPTION
The grid for the form rows was cutting off the penalty input but still displaying it properly just not forwarding clicks/inputs through. The changes update the grid so the table is no longer cut off.